### PR TITLE
Replace UNPKG w/ jsDelivr

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -1,5 +1,5 @@
-import * as OpenCV from 'https://unpkg.com/opencv-wasm@4.3.0-10/types/opencv.ts';
-import {cv as _cv} from 'https://unpkg.com/opencv-wasm@4.3.0-10/opencv-deno.js';
+import * as OpenCV from 'https://cdn.jsdelivr.net/npm/opencv-wasm@4.3.0-10/types/opencv.ts';
+import {cv as _cv} from 'https://cdn.jsdelivr.net/npm/opencv-wasm@4.3.0-10/opencv-deno.js';
 
 export const cv: typeof OpenCV = _cv;
 

--- a/notes.txt
+++ b/notes.txt
@@ -14,5 +14,5 @@
     - README installation
 - Dry run publishing NPM module
 - Publish NPM module
-- Try to use the deno using unpkg (https://unpkg.com/opencv-wasm@<version>/mod.ts), see if the type is working.
+- Try to use the deno using jsDelivr (https://cdn.jsdelivr.net/npm/opencv-wasm@<version>/mod.ts), see if the type is working.
 - If unpkg is working fine, then tag it.


### PR DESCRIPTION
UNPKG has not been actively maintained and ~~has been down since `Mar 15, 2025`~~ was down from Mar 15, 2025, 2:00 AM and down for 18 hours (https://github.com/unpkg/unpkg/issues/412). Migrating to jsDelivr means a more stable and reliant service.

The PR replaces UNPKG usage with jsDelivr.